### PR TITLE
query optimize

### DIFF
--- a/src/components/TodoPreview.tsx
+++ b/src/components/TodoPreview.tsx
@@ -2,7 +2,7 @@ import { truncate } from '../utils/truncate'
 import { TodoItem } from './TodoItem'
 import { todoSkeletons } from './TodoSkeleton'
 import { Stack, Text } from '@mantine/core'
-import { useGetTodosQuery } from 'queries'
+import { useTodosQuery } from 'queries'
 import { match } from 'ts-pattern'
 import { Todo } from 'types'
 
@@ -21,7 +21,7 @@ const todoList = (todos: Todo[]) => () =>
   )
 
 export const TodoPreview = () => {
-  const { data: todos, status } = useGetTodosQuery()
+  const { data: todos, status } = useTodosQuery()
 
   const content = match(status)
     .with('loading', () => todoSkeletons)

--- a/src/queries/todo.ts
+++ b/src/queries/todo.ts
@@ -13,10 +13,10 @@ export const queryClient = new QueryClient({
   }),
 })
 
-export const useGetTodosQuery = () =>
+export const useTodosQuery = () =>
   useQuery({ queryKey: ['todos'], queryFn: getTodos })
 
-export const useGetTodoQuery = (id: string) =>
+export const useTodoQuery = (id: string) =>
   useQuery({ queryKey: ['todos', id], queryFn: () => getTodoById({ id }) })
 
 export const useCreateTodoMutation = () =>

--- a/src/queries/todo.ts
+++ b/src/queries/todo.ts
@@ -5,6 +5,7 @@ import {
   useQuery,
 } from '@tanstack/react-query'
 import { createTodo, deleteTodo, getTodoById, getTodos, updateTodo } from 'api'
+import { Todo } from 'types'
 
 export const queryClient = new QueryClient({
   queryCache: new QueryCache({
@@ -13,11 +14,13 @@ export const queryClient = new QueryClient({
   }),
 })
 
-export const useTodosQuery = () =>
-  useQuery({ queryKey: ['todos'], queryFn: getTodos })
+export const useTodosQuery = <T>(select?: (data: Todo[]) => T) =>
+  useQuery({ queryKey: ['todos'], queryFn: getTodos, select })
+
+export const useTodosCount = () => useTodosQuery<number>((data) => data.length)
 
 export const useTodoQuery = (id: string) =>
-  useQuery({ queryKey: ['todos', id], queryFn: () => getTodoById({ id }) })
+  useTodosQuery((data) => data.find((todo) => todo.id === id))
 
 export const useCreateTodoMutation = () =>
   useMutation(createTodo, {

--- a/src/routes/Home.tsx
+++ b/src/routes/Home.tsx
@@ -1,12 +1,12 @@
 import { Paper, SimpleGrid, Text, Title } from '@mantine/core'
 import { usePrevious } from '@mantine/hooks'
 import { TodoPreview } from 'components'
-import { useGetTodoQuery } from 'queries'
+import { useTodoQuery } from 'queries'
 import { useLocation } from 'react-router-dom'
 
 type Props = { id: string }
 export const TodoContent = ({ id }: Props) => {
-  const { data, isSuccess } = useGetTodoQuery(id)
+  const { data, isSuccess } = useTodoQuery(id)
   const previous = usePrevious(data)
   const todo = isSuccess ? data : previous
 


### PR DESCRIPTION
### perf: `todos/id` 쿼리 최적화 (1847efb)

`useQuery`의 `selector` 기능을 사용하여 쿼리를 1번
만 사용

### refactor: 쿼리문에서 Get 제거 (d1a3e36)

Query와 동어반복